### PR TITLE
Add advice to ensure copying of src files to app

### DIFF
--- a/app/ns-ui-widgets-category/web-view/source-load/article.md
+++ b/app/ns-ui-widgets-category/web-view/source-load/article.md
@@ -3,6 +3,7 @@ The example demonstrates, how to load content in the WebView component, while us
 XML
 <snippet id='web-view-xml-local-file'/>
 
-Add WebView `src` from local file
+Add WebView `src` from local file. You might need to add a glob for your HTML paths to the copy plugin in webpack.config.js. e.g. `new CopyWebpackPlugin([ { from: { glob: "www/*.html" } }]`
+
 <snippet id='web-view-src-local-file'/>
 <snippet id='web-view-src-local-file-ts'/>


### PR DESCRIPTION
Added advice -- the of CopyWebpackPlugin globs -- to mitigate errors in loading local src files because they were not copied to from the source code as mentioned on https://github.com/NativeScript/NativeScript/issues/6377#issuecomment-538769636